### PR TITLE
update model.py

### DIFF
--- a/cegads/appliances/model.py
+++ b/cegads/appliances/model.py
@@ -71,7 +71,7 @@ class ApplianceModel(object):
         indices = lookup.searchsorted(random_data, side='right')
         # add a series of days onto the dates
         dates = pd.Series(profile.index[indices]) + pd.to_timedelta(np.arange(len(indices)), unit='d')
-        dates = pd.Index(dates, name=name).to_datetime()
+        dates = pd.to_datetime(pd.Index(dates, name=name))
         return dates.shift(1, start.replace(microsecond=0, second=0, minute=0, hour=0) - dates[0].replace(microsecond=0, second=0, minute=0, hour=0))
 
 


### PR DESCRIPTION
if pandas version is 0.22+, then to_datetime() module is used as pd.to_datetime(arg) now.